### PR TITLE
Update const.py

### DIFF
--- a/custom_components/idrac_power_monitor/const.py
+++ b/custom_components/idrac_power_monitor/const.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 
-DOMAIN = 'idrac_power_monitor'
+DOMAIN = 'idrac_power'
 
 DATA_IDRAC_REST_CLIENT = 'client'
 


### PR DESCRIPTION
I believe this needs to match what's in the manifest. Or at least, I needed to change this in order for the integration config to load.

Note I've gone with simply "idrac_power" as that is what is used in your documentation. If you prefer idrac_power_monitor then we can change the manifest instead.