### PR TITLE
Minor tweaks - uniqueness

### DIFF
--- a/custom_components/idrac_power/binary_sensor.py
+++ b/custom_components/idrac_power/binary_sensor.py
@@ -34,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     serial = info[JSON_SERIAL_NUMBER]
 
     device_info = DeviceInfo(
-        identifiers={('serial', serial)},
+        identifiers={(DOMAIN, serial)},
         name=name,
         manufacturer=manufacturer,
         model=model,

--- a/custom_components/idrac_power/button.py
+++ b/custom_components/idrac_power/button.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     )
 
     async_add_entities([
-        IdracPowerONButton(hass, rest_client, device_info, f"{serial}_{name}_status", name),
+        IdracPowerONButton(hass, rest_client, device_info, f"{serial}_{name}_power_on", name),
         IdracRefreshButton(hass, rest_client, device_info, f"{serial}_{name}_refresh", name)
     ])
 
@@ -70,7 +70,7 @@ class IdracRefreshButton(ButtonEntity):
         self.rest = rest
 
         self.entity_description = ButtonEntityDescription(
-            key='power_on',
+            key='refresh',
             name=f"Refresh {name}",
             icon='mdi:power',
             device_class=ButtonDeviceClass.UPDATE,

--- a/custom_components/idrac_power/button.py
+++ b/custom_components/idrac_power/button.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     serial = info[JSON_SERIAL_NUMBER]
 
     device_info = DeviceInfo(
-        identifiers={('serial', serial)},
+        identifiers={(DOMAIN, serial)},
         name=name,
         manufacturer=manufacturer,
         model=model,

--- a/custom_components/idrac_power/sensor.py
+++ b/custom_components/idrac_power/sensor.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     serial = info[JSON_SERIAL_NUMBER]
 
     device_info = DeviceInfo(
-        identifiers={('serial', serial)},
+        identifiers={(DOMAIN, serial)},
         name=name,
         manufacturer=manufacturer,
         model=model,


### PR DESCRIPTION
- Minor change to device identifier so it contains the integration `DOMAIN`

- Fixed power on button having the same `unique_id` as the status binary sensor

- Fixed duplicate entity description key 