### PR TITLE
Feature/add graceful shutdown button

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 119

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This integration will grab infomations from your Dell servers' iDRAC system :
 - CPU and air temperature
 - Fan speed
 
-Youc can also start the server from Home Assistant.
+You can also start and shutdown the server from Home Assistant.
 
 For this to work, the Redfish service must be running on it.
 

--- a/custom_components/idrac_power/binary_sensor.py
+++ b/custom_components/idrac_power/binary_sensor.py
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if DATA_IDRAC_INFO not in hass.data[DOMAIN][entry.entry_id]:
             info = await hass.async_add_executor_job(target=rest_client.get_device_info)
             if not info:
-                raise PlatformNotReady(f"Could not set up: device didn't return anything.")
+                raise PlatformNotReady("Could not set up: device didn't return anything.")
 
             hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_INFO] = info
         else:
@@ -44,7 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_INFO] = firmware_version
     except (CannotConnect, RedfishConfig) as e:
         raise PlatformNotReady(str(e)) from e
-
 
     model = info[JSON_MODEL]
     name = model

--- a/custom_components/idrac_power/button.py
+++ b/custom_components/idrac_power/button.py
@@ -80,6 +80,7 @@ class IdracPowerONButton(ButtonEntity):
     async def async_press(self) -> None:
         await self.hass.async_add_executor_job(self.rest.idrac_reset, 'On')
 
+
 class IdracPowerOffButton(ButtonEntity):
 
     def __init__(self, hass, rest: IdracRest, device_info, unique_id, name):

--- a/custom_components/idrac_power/button.py
+++ b/custom_components/idrac_power/button.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if DATA_IDRAC_INFO not in hass.data[DOMAIN][entry.entry_id]:
             info = await hass.async_add_executor_job(target=rest_client.get_device_info)
             if not info:
-                raise PlatformNotReady(f"Could not set up: device didn't return anything.")
+                raise PlatformNotReady("Could not set up: device didn't return anything.")
 
             hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_INFO] = info
         else:
@@ -55,6 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
     async_add_entities([
         IdracPowerONButton(hass, rest_client, device_info, f"{serial}_{name}_power_on", name),
+        IdracPowerOffButton(hass, rest_client, device_info, f"{serial}_{name}_power_off", name),
         IdracRefreshButton(hass, rest_client, device_info, f"{serial}_{name}_refresh", name)
     ])
 
@@ -77,7 +78,27 @@ class IdracPowerONButton(ButtonEntity):
         self._attr_has_entity_name = True
 
     async def async_press(self) -> None:
-        await self.hass.async_add_executor_job(self.rest.power_on)
+        await self.hass.async_add_executor_job(self.rest.idrac_reset, 'On')
+
+class IdracPowerOffButton(ButtonEntity):
+
+    def __init__(self, hass, rest: IdracRest, device_info, unique_id, name):
+        self.hass = hass
+        self.rest = rest
+
+        self.entity_description = ButtonEntityDescription(
+            key='power_on',
+            name=f"Power OFF {name}",
+            icon='mdi:power',
+            device_class=ButtonDeviceClass.UPDATE,
+        )
+
+        self._attr_device_info = device_info
+        self._attr_unique_id = unique_id
+        self._attr_has_entity_name = True
+
+    async def async_press(self) -> None:
+        await self.hass.async_add_executor_job(self.rest.idrac_reset, 'GracefulShutdown')
 
 
 class IdracRefreshButton(ButtonEntity):

--- a/custom_components/idrac_power/idrac_rest.py
+++ b/custom_components/idrac_power/idrac_rest.py
@@ -6,13 +6,12 @@ import urllib3
 from homeassistant.exceptions import HomeAssistantError
 from requests import Response
 from requests.exceptions import RequestException, JSONDecodeError, HTTPError
-
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
 from .const import (
     JSON_NAME, JSON_MANUFACTURER, JSON_MODEL, JSON_SERIAL_NUMBER,
     JSON_POWER_CONSUMED_WATTS, JSON_FIRMWARE_VERSION, JSON_STATUS, JSON_STATUS_STATE
 )
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,7 +88,7 @@ class IdracRest:
     def idrac_reset(self, reset_type: str) -> Response | None:
         '''
         reset_type (str): On, ForceOff, ForceRestart, GracefulShutdown, PushPowerButton, Nmi
-            Following types of reset can be performed: 
+            Following types of reset can be performed:
                 - On: Turn on the unit.
                 - ForceOff: Turn off the unit immediately (nongraceful shutdown).
                 - ForceRestart: Shut down immediately and nongracefully and restart the system.
@@ -101,13 +100,13 @@ class IdracRest:
         '''
         try:
             response = requests.post(url=f'{protocol}{self.host}{drac_reset_path}',
-                                   auth=self.auth,
-                                   verify=False,
-                                   json={"ResetType": reset_type},
-                                   timeout=300)
+                                     auth=self.auth,
+                                     verify=False,
+                                     json={"ResetType": reset_type},
+                                     timeout=300)
         except RequestException as e:
             raise CannotConnect(f"Could not perform '{reset_type}' iDRAC reset on {self.host}: {e}")
-    
+
         json = None
         status_code = response.status_code
         if status_code == 204:
@@ -116,7 +115,8 @@ class IdracRest:
         elif status_code == 401 or status_code == 403:
             raise InvalidAuth()
         elif status_code == 404:
-            if response.json().get('error', {}).get('code') == 'Base.1.0.GeneralError' and 'RedFish attribute is disabled' in \
+            error = response.json()['error']
+            if error.get('code') == 'Base.1.0.GeneralError' and 'RedFish attribute is disabled' in \
                     error['@Message.ExtendedInfo'][0]['Message']:
                 raise RedfishConfig()
             raise HTTPError()
@@ -137,7 +137,6 @@ class IdracRest:
             _LOGGER.error(f"iDRAC '{reset_type}' iDRAC reset failed: {error_message}")
 
         return response
-
 
     def register_callback_thermals(self, callback: Callable[[dict | None], None]) -> None:
         self.callback_thermals.append(callback)


### PR DESCRIPTION
# Why:
This PR aims to add a 'Turn OFF {server}'  button.  
This can be used to safely shutdown the server remotely or by automation.

# How
This is done by calling the same endpoint as the one to power-on the server.
The call is made with the `reset_type` parameter set to `GracefulShutdown` instead of `On`.
- Refactoring/renaming of the `idrac_rest.power_on()` and renamed to `idrac_rest.idrac_reset()` to accept the `reset_type` parameter.
- Completed the error handling to handle a the 409 status code (eg: trying to shutdown a server that's already down).
- Added `button.IdracPowerOffButton` method to create this button.
- Took the liberty to lint some of the code.

:warning: Newbee warning: Please review and test carefully before merging. While familiar with Python, this is the first time I work on a HA project and I find it surprisingly difficult to be able to iterate efficiently between tests.