### PR TITLE
Feature/add french translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# iDrac power monitor
+# iDRAC power monitor
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 
@@ -26,5 +26,5 @@ Tested on iDRAC 7 and 8 on multiple Dell PowerEdge servers.
 2. Restart HA
 3. Go to `Configuration` -> `Integrations` and click the `+ Add Integration`
    button
-4. Select `iDrac power monitor` from the list
-5. Enter the IP address or hostname (NO `http://` !) of your iDrac instance, its username (`root` by default) and its password (`calvin` by default).
+4. Select `iDRAC power monitor` from the list
+5. Enter the IP address or hostname (NO `http://` !) of your iDRAC instance, its username (`root` by default) and its password (`calvin` by default).

--- a/custom_components/idrac_power/__init__.py
+++ b/custom_components/idrac_power/__init__.py
@@ -1,4 +1,4 @@
-"""iDrac power usage monitor"""
+"""iDRAC power usage monitor"""
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -9,7 +9,7 @@ from .idrac_rest import IdracMock, IdracRest
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up the iDrac connection from a config entry."""
+    """Set up the iDRAC connection from a config entry."""
 
     if entry.data[HOST] == 'MOCK':
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {

--- a/custom_components/idrac_power/binary_sensor.py
+++ b/custom_components/idrac_power/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Platform for iDrac power sensor integration."""
+"""Platform for iDRAC power sensor integration."""
 from __future__ import annotations
 
 import logging
@@ -23,7 +23,7 @@ drac_powercontrol_path = '/redfish/v1/Chassis/System.Embedded.1/Power/PowerContr
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
-    """Add iDrac power sensor entry"""
+    """Add iDRAC power sensor entry"""
     rest_client = hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_REST_CLIENT]
 
     try:
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 
 class IdracStatusBinarySensor(BinarySensorEntity):
-    """The iDrac's current power sensor entity."""
+    """The iDRAC's current power sensor entity."""
 
     def __init__(self, hass, rest: IdracRest, device_info, unique_id, name):
         self.hass = hass

--- a/custom_components/idrac_power/button.py
+++ b/custom_components/idrac_power/button.py
@@ -1,4 +1,4 @@
-"""Platform for iDrac power sensor integration."""
+"""Platform for iDRAC power sensor integration."""
 from __future__ import annotations
 
 import logging
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
-    """Add iDrac power sensor entry"""
+    """Add iDRAC power sensor entry"""
     rest_client = hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_REST_CLIENT]
 
     try:

--- a/custom_components/idrac_power/config_flow.py
+++ b/custom_components/idrac_power/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for the iDrac power usage monitor"""
+"""Config flow for the iDRAC power usage monitor"""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 @config_entries.HANDLERS.register(DOMAIN)
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for iDrac REST."""
+    """Handle a config flow for iDRAC REST."""
 
     VERSION = 1
 

--- a/custom_components/idrac_power/sensor.py
+++ b/custom_components/idrac_power/sensor.py
@@ -1,4 +1,4 @@
-"""Platform for iDrac power sensor integration."""
+"""Platform for iDRAC power sensor integration."""
 from __future__ import annotations
 
 import asyncio
@@ -23,7 +23,7 @@ drac_powercontrol_path = '/redfish/v1/Chassis/System.Embedded.1/Power/PowerContr
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
-    """Add iDrac power sensor entry"""
+    """Add iDRAC power sensor entry"""
     rest_client = hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_REST_CLIENT]
 
     _LOGGER.debug(f"Getting the REST client for {entry.entry_id}")
@@ -119,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 
 class IdracCurrentPowerSensor(SensorEntity):
-    """The iDrac's current power sensor entity."""
+    """The iDRAC's current power sensor entity."""
 
     def __init__(self, hass, rest: IdracRest, device_info, unique_id, name):
         self.hass = hass

--- a/custom_components/idrac_power/strings.json
+++ b/custom_components/idrac_power/strings.json
@@ -1,10 +1,10 @@
 {
-  "title": "iDrac power monitor",
+  "title": "iDRAC power monitor",
   "config": {
     "step": {
       "user": {
-        "title": "iDrac power monitor",
-        "description": "Enter the iDrac's credentials.",
+        "title": "iDRAC power monitor",
+        "description": "Enter the iDRAC's credentials.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",

--- a/custom_components/idrac_power/translations/en.json
+++ b/custom_components/idrac_power/translations/en.json
@@ -1,12 +1,12 @@
 {
-  "title": "iDrac power monitor",
+  "title": "iDRAC power monitor",
   "config": {
     "step": {
       "user": {
         "data": {
-          "host": "Hostname of the iDrac instance",
-          "username": "iDrac username",
-          "password": "iDrac password",
+          "host": "Hostname of the iDRAC instance",
+          "username": "iDRAC username",
+          "password": "iDRAC password",
           "interval": "Interval in seconds between each poll"
         }
       }

--- a/custom_components/idrac_power/translations/fr.json
+++ b/custom_components/idrac_power/translations/fr.json
@@ -1,0 +1,24 @@
+{
+  "title": "Moniteur de puissance iDRAC",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "Nom d'hôte de l'instance iDRAC",
+          "username": "Nom d'utilisateur iDRAC",
+          "password": "Mot de passe iDRAC",
+          "interval": "Intervalle en secondes entre chaque sondage"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Impossible de se connecter",
+      "invalid_auth": "Informations d'identification invalides",
+      "redfish_config": "Redfish n'est pas activé. Démarrez l'interface iDRAC avec un navigateur Web et accédez à la page Serveur -> iDRAC Settings -> Network -> Services -> Redfish. Vérifiez que Enabled est sélectionné.",
+      "unknown": "Erreur inconnue"
+    },
+    "abort": {
+      "already_configured": "Cette intégration a déjà été configurée"
+    }
+  }
+}

--- a/custom_components/idrac_power/translations/nl.json
+++ b/custom_components/idrac_power/translations/nl.json
@@ -1,12 +1,12 @@
 {
-  "title": "iDrac power monitor",
+  "title": "iDRAC power monitor",
   "config": {
     "step": {
       "user": {
         "data": {
-          "host": "Hostnaam van de iDrac instantie",
-          "username": "iDrac gebruikersnaam",
-          "password": "iDrac wachtwoord",
+          "host": "Hostnaam van de iDRAC instantie",
+          "username": "iDRAC gebruikersnaam",
+          "password": "iDRAC wachtwoord",
           "interval": "Interval in seconden tussen elke update"
         }
       }


### PR DESCRIPTION
# Why
No French 🥖 translations was available.

# How
- Added `custom_components/idrac_power/translations/fr.json` containing the French translations. This is solely based on the `custom_components/idrac_power/translations/en.json` file.
- Took the opportunity to standardize the case of iDRAC.