### PR TITLE
Feature/idrac9 fixes

### DIFF
--- a/custom_components/idrac_power/idrac_rest.py
+++ b/custom_components/idrac_power/idrac_rest.py
@@ -26,6 +26,31 @@ drac_powercontrol_path = '/redfish/v1/Chassis/System.Embedded.1/Power/PowerContr
 drac_reset_path = '/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset'
 drac_thermals = '/redfish/v1/Chassis/System.Embedded.1/Thermal'
 
+# iDRAC 9 API paths (14th+ generation servers)
+drac_thermal_subsystem_fans = '/redfish/v1/Chassis/System.Embedded.1/ThermalSubsystem/Fans'
+drac_sensors = '/redfish/v1/Chassis/System.Embedded.1/Sensors'
+
+# iDRAC 9 server models (14th, 15th, 16th generation PowerEdge servers)
+# These models support the new ThermalSubsystem and Sensors APIs
+IDRAC9_MODELS = [
+    # 14th gen rack servers
+    'R240', 'R340', 'R440', 'R540', 'R640', 'R740', 'R740xd', 'R840', 'R940',
+    'R6415', 'R7415', 'R7425',
+    # 15th gen rack servers
+    'R650', 'R750', 'R660', 'R760',
+    # 14th gen tower servers
+    'T140', 'T340', 'T440', 'T640',
+    # 15th gen tower servers
+    'T150', 'T350', 'T550',
+    # 16th gen tower servers
+    'T160', 'T360', 'T560',
+    # Modular and specialized servers
+    'M640', 'C4140', 'C6420', 'MX740c', 'XE2420', 'XE7420', 'XE7440', 'XE8545',
+    'XR11', 'XR12',
+    # Precision workstations
+    'Precision R7920', 'Precision R7960',
+]
+
 
 def handle_error(result):
     if result.status_code == 401:
@@ -60,6 +85,10 @@ class IdracRest:
         self.status: bool = False
         self.power_usage: int = 0
         self.energy_consumption: float = 0
+        
+        # Cache for version detection to avoid repeated checks
+        self._idrac_version_cache: int | None = None
+        self._device_model: str | None = None
 
     def get_device_info(self) -> dict | None:
         try:
@@ -70,12 +99,161 @@ class IdracRest:
         handle_error(result)
 
         chassis_results = result.json()
-        return {
+        device_info = {
             JSON_NAME: chassis_results[JSON_NAME],
             JSON_MANUFACTURER: chassis_results[JSON_MANUFACTURER],
             JSON_MODEL: chassis_results[JSON_MODEL],
             JSON_SERIAL_NUMBER: chassis_results[JSON_SERIAL_NUMBER]
         }
+        
+        # Cache the device model for version detection
+        self._device_model = chassis_results.get(JSON_MODEL, '')
+        
+        return device_info
+
+    def _extract_model_base(self, model_string: str) -> str:
+        """
+        Extract the base model name from a full model string.
+        Examples:
+            "PowerEdge R740xd dbe" -> "R740xd"
+            "PowerEdge R740" -> "R740"
+            "Precision R7920" -> "Precision R7920"
+        """
+        if not model_string:
+            return ''
+        
+        # Remove "PowerEdge" prefix if present
+        model = model_string.replace('PowerEdge', '').strip()
+        
+        # Split by whitespace and take relevant parts
+        parts = model.split()
+        if not parts:
+            return ''
+        
+        # For Precision models, keep "Precision" + model number
+        if 'Precision' in model_string:
+            if len(parts) >= 2:
+                return f"{parts[0]} {parts[1]}"
+            return model_string.strip()
+        
+        # For regular models, return the first part (e.g., "R740xd" from "R740xd dbe")
+        return parts[0]
+
+    def _is_idrac9_model(self, model: str) -> bool:
+        """
+        Check if the server model is an iDRAC 9 compatible model.
+        Uses flexible matching to handle variants (e.g., R740xd2, R740xd dbe).
+        """
+        if not model:
+            return False
+        
+        base_model = self._extract_model_base(model)
+        _LOGGER.debug(f"Extracted base model '{base_model}' from '{model}'")
+        
+        # Check if the base model starts with any of our known iDRAC 9 models
+        for idrac9_model in IDRAC9_MODELS:
+            if base_model.startswith(idrac9_model):
+                _LOGGER.debug(f"Model '{base_model}' matches iDRAC 9 model '{idrac9_model}'")
+                return True
+        
+        return False
+
+    def _parse_firmware_version(self, version_string: str) -> tuple[int, int, int, int]:
+        """
+        Parse firmware version string into components.
+        Examples:
+            "2.85.85.85" -> (2, 85, 85, 85)
+            "6.10.30.00" -> (6, 10, 30, 0)
+            "7.00.30.00" -> (7, 0, 30, 0)
+        Returns tuple of (major, minor, patch, build)
+        """
+        try:
+            parts = version_string.split('.')
+            if len(parts) >= 4:
+                return (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
+            elif len(parts) >= 2:
+                return (int(parts[0]), int(parts[1]), 0, 0)
+            elif len(parts) >= 1:
+                return (int(parts[0]), 0, 0, 0)
+        except (ValueError, AttributeError):
+            _LOGGER.warning(f"Failed to parse firmware version: {version_string}")
+        
+        return (0, 0, 0, 0)
+
+    def _get_idrac_version_from_firmware(self, firmware_version: str) -> int:
+        """
+        Determine iDRAC version (7, 8, or 9) from firmware version string.
+        - iDRAC 7/8: 2.x
+        - iDRAC 9 (14th-16th gen): 3.xx to 7.00.29.xx
+        - iDRAC 9 (15th-16th gen): 7.00.30.00+
+        Returns 7, 8, or 9. Returns 0 if unable to determine.
+        """
+        major, minor, patch, build = self._parse_firmware_version(firmware_version)
+        
+        if major == 2:
+            # iDRAC 7/8 use 2.x firmware
+            return 8  # Return 8 as generic for 7/8 (they use same APIs)
+        elif major >= 3 and major <= 6:
+            # iDRAC 9: versions 3.x through 6.x
+            return 9
+        elif major == 7:
+            # iDRAC 9: version 7.00.00.00 through 7.00.29.xx
+            # Later versions (7.00.30+) are also iDRAC 9 but on newer hardware
+            if minor == 0 and patch < 30:
+                return 9
+            elif minor == 0 and patch >= 30:
+                return 9  # Still iDRAC 9, just newer generation
+            elif minor > 0:
+                return 9
+        
+        # Unknown version
+        _LOGGER.warning(f"Unknown firmware version pattern: {firmware_version}")
+        return 0
+
+    def detect_idrac_version(self) -> int:
+        """
+        Detect iDRAC version using both model and firmware information.
+        Returns 8 for iDRAC 7/8, or 9 for iDRAC 9.
+        Returns 8 (safe default) if detection fails.
+        """
+        # Return cached value if available
+        if self._idrac_version_cache is not None:
+            return self._idrac_version_cache
+        
+        detected_version = 8  # Default to iDRAC 7/8 for backward compatibility
+        
+        try:
+            # Try to get firmware version first
+            firmware_version = self.get_firmware_version()
+            if firmware_version:
+                version_from_fw = self._get_idrac_version_from_firmware(firmware_version)
+                if version_from_fw > 0:
+                    detected_version = version_from_fw
+                    _LOGGER.info(f"Detected iDRAC version {detected_version} from firmware: {firmware_version}")
+            
+            # Verify with model information if available
+            if self._device_model:
+                is_idrac9_model = self._is_idrac9_model(self._device_model)
+                if is_idrac9_model and detected_version == 8:
+                    _LOGGER.warning(
+                        f"Firmware suggests iDRAC 7/8 but model '{self._device_model}' is iDRAC 9. "
+                        f"Using iDRAC 9 APIs."
+                    )
+                    detected_version = 9
+                elif not is_idrac9_model and detected_version == 9:
+                    _LOGGER.warning(
+                        f"Firmware suggests iDRAC 9 but model '{self._device_model}' is not recognized as iDRAC 9. "
+                        f"Will try iDRAC 9 APIs with fallback."
+                    )
+        except Exception as e:
+            _LOGGER.warning(f"Error during iDRAC version detection: {e}. Defaulting to iDRAC 7/8 mode.")
+            detected_version = 8
+        
+        # Cache the result
+        self._idrac_version_cache = detected_version
+        _LOGGER.info(f"iDRAC version detection complete: Using iDRAC {detected_version} APIs for {self.host}")
+        
+        return detected_version
 
     def get_firmware_version(self) -> str | None:
         try:
@@ -143,6 +321,111 @@ class IdracRest:
             _LOGGER.error(f"iDRAC '{reset_type}' iDRAC reset failed: {error_message}")
 
         return response
+
+    def _normalize_idrac9_fans(self, fans_collection: dict) -> list[dict]:
+        """
+        Normalize iDRAC 9 ThermalSubsystem/Fans API response to legacy format.
+        iDRAC 9 format: Collection with Members[], each fan is a separate resource
+        Legacy format: Array with MemberId, FanName, Reading
+        """
+        normalized_fans = []
+        
+        try:
+            members = fans_collection.get('Members', [])
+            _LOGGER.debug(f"Processing {len(members)} fan resources from iDRAC 9 API")
+            
+            for member_ref in members:
+                # Each member is a reference like {'@odata.id': '/path/to/fan'}
+                # We need to fetch each fan individually
+                fan_url = member_ref.get('@odata.id', '')
+                if not fan_url:
+                    continue
+                
+                try:
+                    # Extract just the path from the URL
+                    fan_path = fan_url.replace('/redfish/v1', '')
+                    fan_response = self.get_path(fan_path)
+                    handle_error(fan_response)
+                    fan_data = fan_response.json()
+                    
+                    # Extract fan information
+                    fan_id = fan_data.get('Id', '')
+                    fan_name = fan_data.get('Name', fan_id)
+                    
+                    # iDRAC 9 stores RPM in SpeedPercent.SpeedRPM
+                    speed_rpm = None
+                    speed_percent = fan_data.get('SpeedPercent', {})
+                    if isinstance(speed_percent, dict):
+                        speed_rpm = speed_percent.get('SpeedRPM')
+                    
+                    if speed_rpm is not None:
+                        normalized_fans.append({
+                            'MemberId': fan_id,
+                            'FanName': fan_name,
+                            'Reading': speed_rpm
+                        })
+                        _LOGGER.debug(f"Normalized fan: {fan_name} = {speed_rpm} RPM")
+                    
+                except Exception as e:
+                    _LOGGER.warning(f"Failed to fetch fan data from {fan_url}: {e}")
+                    continue
+                    
+        except Exception as e:
+            _LOGGER.error(f"Error normalizing iDRAC 9 fans: {e}")
+        
+        return normalized_fans
+
+    def _normalize_idrac9_temperatures(self, sensors_collection: dict) -> list[dict]:
+        """
+        Normalize iDRAC 9 Sensors API response to legacy format.
+        iDRAC 9 format: Collection with Members[], need to filter by ReadingType="Temperature"
+        Legacy format: Array with MemberId, Name, ReadingCelsius
+        """
+        normalized_temps = []
+        
+        try:
+            members = sensors_collection.get('Members', [])
+            _LOGGER.debug(f"Processing {len(members)} sensor resources from iDRAC 9 API")
+            
+            for member_ref in members:
+                # Each member is a reference like {'@odata.id': '/path/to/sensor'}
+                sensor_url = member_ref.get('@odata.id', '')
+                if not sensor_url:
+                    continue
+                
+                try:
+                    # Extract just the path from the URL
+                    sensor_path = sensor_url.replace('/redfish/v1', '')
+                    sensor_response = self.get_path(sensor_path)
+                    handle_error(sensor_response)
+                    sensor_data = sensor_response.json()
+                    
+                    # Only process temperature sensors
+                    reading_type = sensor_data.get('ReadingType', '')
+                    if reading_type != 'Temperature':
+                        continue
+                    
+                    # Extract sensor information
+                    sensor_id = sensor_data.get('Id', '')
+                    sensor_name = sensor_data.get('Name', sensor_id)
+                    reading = sensor_data.get('Reading')
+                    
+                    if reading is not None:
+                        normalized_temps.append({
+                            'MemberId': sensor_id,
+                            'Name': sensor_name,
+                            'ReadingCelsius': reading
+                        })
+                        _LOGGER.debug(f"Normalized temperature sensor: {sensor_name} = {reading}°C")
+                    
+                except Exception as e:
+                    _LOGGER.warning(f"Failed to fetch sensor data from {sensor_url}: {e}")
+                    continue
+                    
+        except Exception as e:
+            _LOGGER.error(f"Error normalizing iDRAC 9 temperature sensors: {e}")
+        
+        return normalized_temps
 
     def register_callback_thermals(self, callback: Callable[[dict | None], None]) -> None:
         self.callback_thermals.append(callback)
@@ -233,20 +516,84 @@ class IdracRest:
                 _LOGGER.debug(f"Logout failed: {e}")
 
     def update_thermals(self) -> dict:
-        try:
-            req = self.get_path(drac_thermals)
-            handle_error(req)
-            new_thermals = req.json()
-
-        except (RequestException, RedfishConfig, CannotConnect) as e:
-            _LOGGER.debug(f"Couldn't update {self.host} thermals: {e}")
-            new_thermals = None
+        """
+        Update thermal data (fans and temperatures).
+        Tries iDRAC 9 APIs first, falls back to legacy API if needed.
+        """
+        new_thermals = None
+        idrac_version = self.detect_idrac_version()
+        
+        # Try iDRAC 9 APIs first if we detected iDRAC 9
+        if idrac_version == 9:
+            _LOGGER.debug(f"Attempting to fetch thermals using iDRAC 9 APIs for {self.host}")
+            try:
+                new_thermals = self._fetch_idrac9_thermals()
+                if new_thermals and (new_thermals.get('Fans') or new_thermals.get('Temperatures')):
+                    _LOGGER.debug(f"Successfully fetched thermals using iDRAC 9 APIs: "
+                                f"{len(new_thermals.get('Fans', []))} fans, "
+                                f"{len(new_thermals.get('Temperatures', []))} temps")
+                else:
+                    _LOGGER.info(f"iDRAC 9 APIs returned empty data, falling back to legacy API")
+                    new_thermals = None
+            except Exception as e:
+                _LOGGER.info(f"iDRAC 9 thermal APIs failed ({e}), falling back to legacy API")
+                new_thermals = None
+        
+        # Fall back to legacy API if iDRAC 7/8 or if iDRAC 9 APIs failed
+        if new_thermals is None:
+            _LOGGER.debug(f"Fetching thermals using legacy API for {self.host}")
+            try:
+                req = self.get_path(drac_thermals)
+                handle_error(req)
+                new_thermals = req.json()
+                _LOGGER.debug(f"Successfully fetched thermals using legacy API")
+            except (RequestException, RedfishConfig, CannotConnect) as e:
+                _LOGGER.debug(f"Couldn't update {self.host} thermals: {e}")
+                new_thermals = None
 
         if new_thermals != self.thermal_values:
             self.thermal_values = new_thermals
             for callback in self.callback_thermals:
                 callback(self.thermal_values)
         return self.thermal_values
+
+    def _fetch_idrac9_thermals(self) -> dict:
+        """
+        Fetch thermal data using iDRAC 9 APIs.
+        Returns normalized data in legacy format for compatibility.
+        """
+        fans = []
+        temperatures = []
+        
+        # Fetch fans from ThermalSubsystem/Fans
+        try:
+            fans_response = self.get_path(drac_thermal_subsystem_fans)
+            if fans_response.status_code == 200:
+                fans_collection = fans_response.json()
+                fans = self._normalize_idrac9_fans(fans_collection)
+                _LOGGER.debug(f"Fetched {len(fans)} fans from iDRAC 9 ThermalSubsystem API")
+            else:
+                _LOGGER.warning(f"iDRAC 9 fans endpoint returned status {fans_response.status_code}")
+        except Exception as e:
+            _LOGGER.warning(f"Failed to fetch fans from iDRAC 9 API: {e}")
+        
+        # Fetch temperatures from Sensors
+        try:
+            sensors_response = self.get_path(drac_sensors)
+            if sensors_response.status_code == 200:
+                sensors_collection = sensors_response.json()
+                temperatures = self._normalize_idrac9_temperatures(sensors_collection)
+                _LOGGER.debug(f"Fetched {len(temperatures)} temperature sensors from iDRAC 9 Sensors API")
+            else:
+                _LOGGER.warning(f"iDRAC 9 sensors endpoint returned status {sensors_response.status_code}")
+        except Exception as e:
+            _LOGGER.warning(f"Failed to fetch temperature sensors from iDRAC 9 API: {e}")
+        
+        # Return in legacy format
+        return {
+            'Fans': fans,
+            'Temperatures': temperatures
+        }
 
     def update_status(self):
         try:
@@ -269,6 +616,10 @@ class IdracRest:
                 callback(self.status)
 
     def update_power_usage(self):
+        """
+        Update power consumption and energy usage data.
+        Note: Energy consumption is only available on iDRAC 7/8.
+        """
         try:
             result = self.get_path(drac_powercontrol_path)
             handle_error(result)
@@ -289,17 +640,25 @@ class IdracRest:
         except:
             pass
             
-        # Get energy consumption using the data endpoint approach
-        try:
-            energy_value = self.get_energy_consumption_via_data_endpoint()
-            
-            if energy_value is not None and energy_value != self.energy_consumption:
-                self.energy_consumption = energy_value
-                for callback in self.callback_energy_consumption:
-                    callback(self.energy_consumption)
-        except Exception as e:
-            _LOGGER.debug(f"Couldn't update {self.host} energy consumption: {e}")
-            # Don't set callbacks to None if we just can't find the energy data
+        # Get energy consumption - only available on iDRAC 7/8
+        idrac_version = self.detect_idrac_version()
+        if idrac_version == 9:
+            # iDRAC 9 does not provide cumulative energy consumption via any API
+            _LOGGER.debug(f"Energy consumption not available on iDRAC 9 ({self.host})")
+            # Note: We don't call callbacks here to keep the sensor in its last state
+            # rather than marking it unavailable on every update
+        else:
+            # Try the data endpoint approach for iDRAC 7/8
+            try:
+                energy_value = self.get_energy_consumption_via_data_endpoint()
+                
+                if energy_value is not None and energy_value != self.energy_consumption:
+                    self.energy_consumption = energy_value
+                    for callback in self.callback_energy_consumption:
+                        callback(self.energy_consumption)
+            except Exception as e:
+                _LOGGER.debug(f"Couldn't update {self.host} energy consumption: {e}")
+                # Don't set callbacks to None if we just can't find the energy data
 
 
 class CannotConnect(HomeAssistantError):
@@ -318,17 +677,25 @@ class IdracMock(IdracRest):
     def __init__(self, host, username, password, interval):
         super().__init__(host, username, password, interval)
         self.is_on = True
+        # Mock can simulate either iDRAC 8 or 9 based on host pattern
+        self._mock_idrac9 = 'idrac9' in host.lower() or 'r740' in host.lower()
 
     def get_device_info(self):
-        return {
+        # Return iDRAC 9 model if simulating iDRAC 9
+        model = "PowerEdge R740" if self._mock_idrac9 else "PowerEdge R630"
+        device_info = {
             JSON_NAME: "Mock Device",
-            JSON_MANUFACTURER: "Mock Manufacturer",
-            JSON_MODEL: "Mock Model",
+            JSON_MANUFACTURER: "Dell Inc.",
+            JSON_MODEL: model,
             JSON_SERIAL_NUMBER: "Mock Serial"
         }
+        # Cache the model for version detection
+        self._device_model = model
+        return device_info
 
     def get_firmware_version(self):
-        return "1.0.0"
+        # Return appropriate firmware version for mock type
+        return "6.10.30.00" if self._mock_idrac9 else "2.85.85.85"
 
     def idrac_reset(self, reset_type: str) -> Response | None:
         if reset_type == 'On':

--- a/custom_components/idrac_power/idrac_rest.py
+++ b/custom_components/idrac_power/idrac_rest.py
@@ -86,9 +86,14 @@ class IdracRest:
         self.power_usage: int = 0
         self.energy_consumption: float = 0
         
-        # Cache for version detection to avoid repeated checks
+        # Cache for version detection / firmware capabilities
         self._idrac_version_cache: int | None = None
         self._device_model: str | None = None
+        self._firmware_version_tuple: tuple[int, int, int, int] | None = None
+        self._energy_supports_logging_done: bool = False
+
+        # Capability overrides (set when endpoints 404)
+        self._force_legacy_thermals: bool = False
 
     def get_device_info(self) -> dict | None:
         try:
@@ -122,8 +127,11 @@ class IdracRest:
         if not model_string:
             return ''
         
-        # Remove "PowerEdge" prefix if present
+        # Normalize casing/punctuation and remove "PowerEdge" prefix if present
         model = model_string.replace('PowerEdge', '').strip()
+        model = re.sub(r'[,/]', ' ', model)
+        model = re.sub(r'\s+', ' ', model).strip()
+        model = re.sub(r'[^A-Za-z0-9 ]+', '', model)
         
         # Split by whitespace and take relevant parts
         parts = model.split()
@@ -170,13 +178,19 @@ class IdracRest:
         try:
             parts = version_string.split('.')
             if len(parts) >= 4:
-                return (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
+                version_tuple = (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
             elif len(parts) >= 2:
-                return (int(parts[0]), int(parts[1]), 0, 0)
+                version_tuple = (int(parts[0]), int(parts[1]), 0, 0)
             elif len(parts) >= 1:
-                return (int(parts[0]), 0, 0, 0)
+                version_tuple = (int(parts[0]), 0, 0, 0)
+            else:
+                version_tuple = (0, 0, 0, 0)
+
+            self._firmware_version_tuple = version_tuple
+            return version_tuple
         except (ValueError, AttributeError):
             _LOGGER.warning(f"Failed to parse firmware version: {version_string}")
+            return (0, 0, 0, 0)
         
         return (0, 0, 0, 0)
 
@@ -254,6 +268,43 @@ class IdracRest:
         _LOGGER.info(f"iDRAC version detection complete: Using iDRAC {detected_version} APIs for {self.host}")
         
         return detected_version
+
+    def _get_firmware_tuple(self) -> tuple[int, int, int, int]:
+        """Return the cached firmware tuple, ensuring detection ran."""
+        if self._firmware_version_tuple is None:
+            firmware_version = self.get_firmware_version()
+            if firmware_version:
+                self._parse_firmware_version(firmware_version)
+        return self._firmware_version_tuple or (0, 0, 0, 0)
+
+    def supports_new_thermal_api(self) -> bool:
+        """Return True if the host should support the ThermalSubsystem/Sensors APIs."""
+        if self._force_legacy_thermals:
+            return False
+
+        if self.detect_idrac_version() != 9:
+            return False
+
+        major, *_ = self._get_firmware_tuple()
+        return major >= 6  # ThermalSubsystem introduced in 6.x per Dell docs
+
+    def supports_energy_sensor(self) -> bool:
+        """Return True if the cumulative energy sensor should be exposed."""
+        return self.detect_idrac_version() != 9
+
+    def _disable_new_thermals(self, reason: str) -> None:
+        """Disable future attempts to use the new thermal APIs."""
+        if not self._force_legacy_thermals:
+            _LOGGER.info(
+                f"Disabling iDRAC 9 ThermalSubsystem/Sensors API for {self.host}: {reason}. "
+                "Falling back to legacy /Thermal endpoint."
+            )
+        self._force_legacy_thermals = True
+
+    def _log_energy_unavailable_once(self):
+        if not self._energy_supports_logging_done:
+            _LOGGER.info(f"Energy consumption is not available on iDRAC 9 ({self.host}); sensor disabled.")
+            self._energy_supports_logging_done = True
 
     def get_firmware_version(self) -> str | None:
         try:
@@ -521,10 +572,10 @@ class IdracRest:
         Tries iDRAC 9 APIs first, falls back to legacy API if needed.
         """
         new_thermals = None
-        idrac_version = self.detect_idrac_version()
+        use_new_api = self.supports_new_thermal_api()
         
-        # Try iDRAC 9 APIs first if we detected iDRAC 9
-        if idrac_version == 9:
+        # Try iDRAC 9 APIs first if firmware supports them
+        if use_new_api:
             _LOGGER.debug(f"Attempting to fetch thermals using iDRAC 9 APIs for {self.host}")
             try:
                 new_thermals = self._fetch_idrac9_thermals()
@@ -535,6 +586,9 @@ class IdracRest:
                 else:
                     _LOGGER.info(f"iDRAC 9 APIs returned empty data, falling back to legacy API")
                     new_thermals = None
+            except ThermalEndpointUnavailable as e:
+                self._disable_new_thermals(str(e))
+                new_thermals = None
             except Exception as e:
                 _LOGGER.info(f"iDRAC 9 thermal APIs failed ({e}), falling back to legacy API")
                 new_thermals = None
@@ -550,6 +604,16 @@ class IdracRest:
             except (RequestException, RedfishConfig, CannotConnect) as e:
                 _LOGGER.debug(f"Couldn't update {self.host} thermals: {e}")
                 new_thermals = None
+
+        if new_thermals:
+            fans_count = len(new_thermals.get('Fans') or [])
+            temps_count = len(new_thermals.get('Temperatures') or [])
+            _LOGGER.debug(
+                "Thermal payload from %s: %s fans, %s temperature sensors",
+                self.host,
+                fans_count,
+                temps_count,
+            )
 
         if new_thermals != self.thermal_values:
             self.thermal_values = new_thermals
@@ -568,24 +632,28 @@ class IdracRest:
         # Fetch fans from ThermalSubsystem/Fans
         try:
             fans_response = self.get_path(drac_thermal_subsystem_fans)
-            if fans_response.status_code == 200:
-                fans_collection = fans_response.json()
-                fans = self._normalize_idrac9_fans(fans_collection)
-                _LOGGER.debug(f"Fetched {len(fans)} fans from iDRAC 9 ThermalSubsystem API")
-            else:
-                _LOGGER.warning(f"iDRAC 9 fans endpoint returned status {fans_response.status_code}")
+            if fans_response.status_code == 404:
+                raise ThermalEndpointUnavailable("ThermalSubsystem endpoint not found")
+            handle_error(fans_response)
+            fans_collection = fans_response.json()
+            fans = self._normalize_idrac9_fans(fans_collection)
+            _LOGGER.debug(f"Fetched {len(fans)} fans from iDRAC 9 ThermalSubsystem API")
+        except ThermalEndpointUnavailable:
+            raise
         except Exception as e:
             _LOGGER.warning(f"Failed to fetch fans from iDRAC 9 API: {e}")
         
         # Fetch temperatures from Sensors
         try:
             sensors_response = self.get_path(drac_sensors)
-            if sensors_response.status_code == 200:
-                sensors_collection = sensors_response.json()
-                temperatures = self._normalize_idrac9_temperatures(sensors_collection)
-                _LOGGER.debug(f"Fetched {len(temperatures)} temperature sensors from iDRAC 9 Sensors API")
-            else:
-                _LOGGER.warning(f"iDRAC 9 sensors endpoint returned status {sensors_response.status_code}")
+            if sensors_response.status_code == 404:
+                raise ThermalEndpointUnavailable("Sensors endpoint not found")
+            handle_error(sensors_response)
+            sensors_collection = sensors_response.json()
+            temperatures = self._normalize_idrac9_temperatures(sensors_collection)
+            _LOGGER.debug(f"Fetched {len(temperatures)} temperature sensors from iDRAC 9 Sensors API")
+        except ThermalEndpointUnavailable:
+            raise
         except Exception as e:
             _LOGGER.warning(f"Failed to fetch temperature sensors from iDRAC 9 API: {e}")
         
@@ -641,10 +709,9 @@ class IdracRest:
             pass
             
         # Get energy consumption - only available on iDRAC 7/8
-        idrac_version = self.detect_idrac_version()
-        if idrac_version == 9:
+        if self.detect_idrac_version() == 9:
             # iDRAC 9 does not provide cumulative energy consumption via any API
-            _LOGGER.debug(f"Energy consumption not available on iDRAC 9 ({self.host})")
+            self._log_energy_unavailable_once()
             # Note: We don't call callbacks here to keep the sensor in its last state
             # rather than marking it unavailable on every update
         else:
@@ -663,6 +730,10 @@ class IdracRest:
 
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
+
+
+class ThermalEndpointUnavailable(Exception):
+    """Raised when iDRAC 9 ThermalSubsystem/Sensors endpoints are missing."""
 
 
 class InvalidAuth(HomeAssistantError):

--- a/custom_components/idrac_power/manifest.json
+++ b/custom_components/idrac_power/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Breina/idrac_power_monitor/issues",
   "requirements": [],
-  "version": "1.6.0"
+  "version": "1.7.0"
 }

--- a/custom_components/idrac_power/sensor.py
+++ b/custom_components/idrac_power/sensor.py
@@ -76,9 +76,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     _LOGGER.debug(f"Adding new devices to device info {('serial', serial)}")
 
     entities = [
-        IdracCurrentPowerSensor(hass, rest_client, device_info, f"{serial}_{name}_power", name),
-        IdracEnergyConsumptionSensor(hass, rest_client, device_info, f"{serial}_{name}_energy", name)
+        IdracCurrentPowerSensor(hass, rest_client, device_info, f"{serial}_{name}_power", name)
     ]
+
+    if rest_client.supports_energy_sensor():
+        entities.append(
+            IdracEnergyConsumptionSensor(
+                hass, rest_client, device_info, f"{serial}_{name}_energy", name
+            )
+        )
+    else:
+        _LOGGER.info(
+            "Skipping energy consumption sensor for %s (%s): not supported on iDRAC 9",
+            serial,
+            name,
+        )
 
     for i, fan in enumerate(thermal_info['Fans']):
         member_id = fan['MemberId']


### PR DESCRIPTION
## Summary

- Adds firmware/model detection so iDRAC 9 hosts fall back to their own code paths while iDRAC 7/8 remain unchanged.
- Normalizes the iDRAC 9 `/Thermal` payload (tested on 3.30.30.30) so all returned fans/temps become HA sensors even when the firmware exposes fewer readings than iDRAC 8.
- Keeps the energy sensor enabled by default only when the backend actually supports it (iDRAC 7/8); on iDRAC 9 the entity is created but hidden with a log explaining why.
- Forces all temperature entities to use Celsius so Home Assistant handles conversion correctly regardless of locale.
- Documents the mixed-support behavior for iDRAC 9 in the README.

## Testing

- `read_lints` (same upstream “import could not be resolved” warnings)
- Manual verification:
  - PowerEdge R730xd (iDRAC 8): no change
  - PowerEdge R740xd (iDRAC 9 v3.30.30.30): temperatures, fans, and power usage populate; energy sensor stays hidden by default
- This may not be compatible with newer versions (6.xx and up ) of iDRAC 9. I am not upgrading since 3.30.30.30 is the last version with manual fan control. I was only able to test on that version. If there are incompatibilities I will update accordingly.