### PR TITLE
fix: detect firmware version to disable legacy /data endpoint on iDRAC 9 7.x+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # iDRAC power monitor
 
+## Changelog
+
+### 1.7.0
+- Add firmware version detection to disable legacy `/data` endpoint on iDRAC 9 firmware 7.x+ (fixes #41)
+- Prefer Redfish `PowerMetrics.EnergyConsumedKWh` for energy consumption over legacy endpoint
+- Fix error log spam on firmware that removed the `/data/login` endpoint
+- Fix potential `NameError` in legacy endpoint logout when login fails
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Breina/idrac_power_monitor/validate.yaml)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Breina/idrac_power_monitor/hassfest.yaml)

--- a/custom_components/idrac_power/__init__.py
+++ b/custom_components/idrac_power/__init__.py
@@ -34,6 +34,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DATA_IDRAC_REST_CLIENT: rest_client
     }
 
+    # Detect firmware version to configure client capabilities
+    try:
+        firmware_version = await hass.async_add_executor_job(rest_client.get_firmware_version)
+        if firmware_version:
+            rest_client.configure_firmware(firmware_version)
+    except Exception as e:
+        _LOGGER.warning(f"Could not detect firmware version for {entry.entry_id}: {e}")
+
     await hass.config_entries.async_forward_entry_setups(
         entry, [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SWITCH]
     )

--- a/custom_components/idrac_power/idrac_rest.py
+++ b/custom_components/idrac_power/idrac_rest.py
@@ -61,6 +61,28 @@ class IdracRest:
         self.power_usage: int = 0
         self.energy_consumption: float = 0
 
+        self._firmware_version: str | None = None
+        self._legacy_endpoint_supported: bool = True
+
+    def configure_firmware(self, firmware_version: str) -> None:
+        """Configure client capabilities based on detected firmware version."""
+        self._firmware_version = firmware_version
+        try:
+            major_version = int(firmware_version.split('.')[0])
+            # iDRAC 9 firmware 7.x+ removed the legacy /data endpoint
+            self._legacy_endpoint_supported = major_version < 7
+            if not self._legacy_endpoint_supported:
+                _LOGGER.info(
+                    "Firmware %s detected on %s - legacy /data endpoint disabled, using Redfish only",
+                    firmware_version, self.host
+                )
+        except (ValueError, IndexError):
+            _LOGGER.warning(
+                "Could not parse firmware version '%s' on %s, legacy endpoint remains enabled",
+                firmware_version, self.host
+            )
+            self._legacy_endpoint_supported = True
+
     def get_device_info(self) -> dict | None:
         try:
             result = self.get_path(drac_chassis_path)
@@ -158,79 +180,77 @@ class IdracRest:
         self.callback_energy_consumption.append(callback)
         
     def get_energy_consumption_via_data_endpoint(self) -> float | None:
-        """Get energy consumption using the /data endpoint approach from idrac.py."""
+        """Get energy consumption using the legacy /data endpoint (pre-7.x firmware)."""
+        st1 = None
+        st2 = None
+        login_response = None
         try:
-            # First login to get tokens
             login_url = f"{protocol}{self.host}/data/login"
             payload = {"user": self.auth[0], "password": self.auth[1]}
-            
+
             login_response = requests.post(login_url, data=payload, verify=False, timeout=300)
-            if login_response.status_code != 200:
-                _LOGGER.error(f"Login failed with status code: {login_response.status_code}")
+            if login_response.status_code == 404:
+                _LOGGER.info(
+                    "Legacy /data endpoint not available on %s (HTTP 404) - disabling for future requests",
+                    self.host
+                )
+                self._legacy_endpoint_supported = False
                 return None
-                
-            # Extract ST1 and ST2 tokens from response
+            if login_response.status_code != 200:
+                _LOGGER.debug(f"Legacy login on {self.host} failed with status code: {login_response.status_code}")
+                return None
+
             match = re.search(r'ST1=([^,]+),ST2=([^<"]+)', login_response.text)
             if not match:
-                _LOGGER.error("Failed to extract authentication tokens")
+                _LOGGER.debug("Failed to extract authentication tokens from %s", self.host)
                 return None
-                
+
             st1 = match.group(1)
             st2 = match.group(2)
-            
-            # Get power monitoring data
+
             power_url = f"{protocol}{self.host}/data"
             params = {
-                "get": "powermonitordata,powergraphdata,psRedundancy,pwState,pbtEnabled,activePLPolicy,activePLimit,pwrBudgetVal,powerSupplies,pbMaxWatts"
+                "get": "powermonitordata,powergraphdata,psRedundancy,pwState,"
+                       "pbtEnabled,activePLPolicy,activePLimit,pwrBudgetVal,powerSupplies,pbMaxWatts"
             }
-            
-            headers = {
-                "ST2": st2,
-                "Content-Type": "application/x-www-form-urlencoded"
-            }
-            
+            headers = {"ST2": st2, "Content-Type": "application/x-www-form-urlencoded"}
+
             power_response = requests.post(
-                power_url, 
-                params=params, 
-                cookies=login_response.cookies, 
-                headers=headers,
-                verify=False,
-                timeout=300
+                power_url, params=params, cookies=login_response.cookies,
+                headers=headers, verify=False, timeout=300
             )
-            
+
             if power_response.status_code != 200:
-                _LOGGER.error(f"Power data request failed with status code: {power_response.status_code}")
+                _LOGGER.debug(f"Legacy power data request on {self.host} failed: {power_response.status_code}")
                 return None
-                
-            # Parse the XML response to extract total usage
+
             try:
                 root = ET.fromstring(power_response.text)
                 total_usage_elem = root.find('.//totalUsage')
-                
                 if total_usage_elem is not None and total_usage_elem.text:
                     return float(total_usage_elem.text)
-                else:
-                    _LOGGER.debug("Total usage data not found in the response")
-                    return None
+                _LOGGER.debug("Total usage data not found in legacy response from %s", self.host)
+                return None
             except ET.ParseError as e:
-                _LOGGER.error(f"Failed to parse XML: {e}")
+                _LOGGER.debug(f"Failed to parse legacy XML from {self.host}: {e}")
                 return None
             except ValueError as e:
-                _LOGGER.error(f"Failed to convert total usage to float: {e}")
+                _LOGGER.debug(f"Failed to convert total usage to float from {self.host}: {e}")
                 return None
-            
+
         except Exception as e:
-            _LOGGER.error(f"Error getting energy consumption via data endpoint: {e}")
+            _LOGGER.debug(f"Error getting energy consumption via legacy endpoint on {self.host}: {e}")
             return None
         finally:
-            # Try to logout to free the session
-            try:
-                logout_url = f"{protocol}{self.host}/data/logout"
-                params = {"ST1": st1}
-                headers = {"ST2": st2}
-                requests.post(logout_url, params=params, headers=headers, cookies=login_response.cookies, verify=False, timeout=300)
-            except Exception as e:
-                _LOGGER.debug(f"Logout failed: {e}")
+            if st1 and st2 and login_response:
+                try:
+                    logout_url = f"{protocol}{self.host}/data/logout"
+                    requests.post(
+                        logout_url, params={"ST1": st1}, headers={"ST2": st2},
+                        cookies=login_response.cookies, verify=False, timeout=300
+                    )
+                except Exception as e:
+                    _LOGGER.debug(f"Legacy logout on {self.host} failed: {e}")
 
     def update_thermals(self) -> dict:
         try:
@@ -288,17 +308,33 @@ class IdracRest:
                     callback(self.power_usage)
         except:
             pass
-            
-        # Get energy consumption using the data endpoint approach
+
+        # Try Redfish energy data first (available on newer firmware)
+        energy_updated = False
         try:
-            energy_value = self.get_energy_consumption_via_data_endpoint()
-            
-            if energy_value is not None and energy_value != self.energy_consumption:
-                self.energy_consumption = energy_value
-                for callback in self.callback_energy_consumption:
-                    callback(self.energy_consumption)
-        except Exception as e:
-            _LOGGER.debug(f"Couldn't update {self.host} energy consumption: {e}")
+            power_metrics = power_values.get(JSON_POWER_METRICS)
+            if power_metrics:
+                energy_kwh = power_metrics.get(JSON_ENERGY_CONSUMED_KWH)
+                if energy_kwh is not None:
+                    energy_value = float(energy_kwh)
+                    if energy_value != self.energy_consumption:
+                        self.energy_consumption = energy_value
+                        for callback in self.callback_energy_consumption:
+                            callback(self.energy_consumption)
+                    energy_updated = True
+        except (KeyError, TypeError, ValueError) as e:
+            _LOGGER.debug(f"Redfish energy data not available for {self.host}: {e}")
+
+        # Fall back to legacy /data endpoint if Redfish didn't provide energy data
+        if not energy_updated and self._legacy_endpoint_supported:
+            try:
+                energy_value = self.get_energy_consumption_via_data_endpoint()
+                if energy_value is not None and energy_value != self.energy_consumption:
+                    self.energy_consumption = energy_value
+                    for callback in self.callback_energy_consumption:
+                        callback(self.energy_consumption)
+            except Exception as e:
+                _LOGGER.debug(f"Couldn't update {self.host} energy consumption via legacy endpoint: {e}")
             # Don't set callbacks to None if we just can't find the energy data
 
 

--- a/custom_components/idrac_power/manifest.json
+++ b/custom_components/idrac_power/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Breina/idrac_power_monitor/issues",
   "requirements": [],
-  "version": "1.6.0"
+  "version": "1.7.0"
 }


### PR DESCRIPTION
## Summary

Fixes #41 — iDRAC 9 firmware 7.x removed the legacy `/data/login` web endpoint, causing `ERROR` log spam every polling cycle.

- Add firmware version detection at setup time (`configure_firmware`) to proactively disable the legacy `/data` endpoint on firmware >= 7.x
- Prefer Redfish `PowerMetrics.EnergyConsumedKWh` for energy consumption data (no extra login/logout round-trip needed)
- Fall back to legacy `/data` endpoint only when Redfish doesn't provide energy data AND firmware supports it
- Safety net: if legacy endpoint returns HTTP 404 at runtime, permanently disable it for the session
- Fix potential `NameError` in legacy endpoint logout when login fails (uninitialized `st1`/`st2` variables in `finally` block)

## Backward compatibility

No breaking changes for iDRAC 7/8 users:
- Legacy endpoint defaults to enabled (`_legacy_endpoint_supported = True`)
- Firmware versions below 7.x explicitly keep legacy enabled
- If firmware detection fails, legacy stays enabled (safe fallback)
- Redfish-first strategy is additive — if Redfish provides energy data it's used, otherwise legacy is attempted as before

## Test results

Tested on iDRAC 9 (PowerEdge T340, firmware 7.x+, HAOS 2026.4.2):

- [x] **iDRAC 9 firmware 7.x+: no ERROR log spam** — legacy `/data` endpoint correctly disabled via firmware detection, no more 404 errors in logs
- [x] **iDRAC 9 firmware 7.x+: power sensor works** — `PowerConsumedWatts` (75-91W) reads correctly via Redfish
- [x] **iDRAC 9 firmware 7.x+: energy sensor** — stays `unknown` as expected; firmware 7.x+ does not expose `EnergyConsumedKWh` in Redfish `PowerMetrics` (only `AverageConsumedWatts`, `MinConsumedWatts`, `MaxConsumedWatts`). This is a firmware limitation, not a regression — the legacy `/data` endpoint that previously provided this value no longer exists either. Users can use HA's Riemann Sum integration on the power sensor as a workaround.
- [ ] **iDRAC 7/8: legacy endpoint** — no test hardware available, code path unchanged from previous behavior
- [ ] **Firmware detection failure** — not tested on real hardware, code defaults to `_legacy_endpoint_supported = True` (safe fallback)
- [x] **Server status / thermal sensors** — binary_sensor and thermal data unaffected, working correctly

## Note on energy consumption

iDRAC 9 firmware 7.x+ removed both the legacy `/data` endpoint and `EnergyConsumedKWh` from Redfish PowerMetrics. Energy consumption tracking requires an external approach (e.g. HA's [Riemann Sum integration](https://www.home-assistant.io/integrations/integration/) on the power usage sensor).