### PR TITLE
fix: resolve sensor state bugs and add async_unload_entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Local dev files
+CLAUDE.md
+TODO.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # iDRAC power monitor
 
+## Changelog
+
+### 1.6.1
+- Fix firmware version overwriting device info, causing platform setup failures on concurrent load
+- Fix power sensor showing "unavailable" instead of 0W when server is in standby
+- Fix binary status sensor showing "unavailable" instead of "off" when server is powered down
+- Add `async_unload_entry` to properly stop background polling and clean up on integration reload
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Breina/idrac_power_monitor/validate.yaml)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Breina/idrac_power_monitor/hassfest.yaml)

--- a/custom_components/idrac_power/__init__.py
+++ b/custom_components/idrac_power/__init__.py
@@ -63,6 +63,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # ignore exceptions, just log the error
             _LOGGER.warning(f"Updating {entry.entry_id} power usage failed:\n{e}")
 
-    hass.async_create_background_task(refresh_sensors_task(), f"Update {entry.entry_id} iDRAC task")
+    task = hass.async_create_background_task(refresh_sensors_task(), f"Update {entry.entry_id} iDRAC task")
+    hass.data[DOMAIN][entry.entry_id]['task'] = task
 
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload an iDRAC config entry."""
+    hass.data[DOMAIN][entry.entry_id]['task'].cancel()
+
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        entry, [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SWITCH]
+    )
+
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/custom_components/idrac_power/binary_sensor.py
+++ b/custom_components/idrac_power/binary_sensor.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             if DATA_IDRAC_FIRMWARE in hass.data[DOMAIN][entry.entry_id]:
                 firmware_version = hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE]
         else:
-            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_INFO] = firmware_version
+            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE] = firmware_version
     except (CannotConnect, RedfishConfig) as e:
         raise PlatformNotReady(str(e)) from e
 
@@ -92,7 +92,7 @@ class IdracStatusBinarySensor(BinarySensorEntity):
         return "Server Status"
 
     def update_value(self, status: bool | None):
-        if status:
+        if status is not None:
             self._attr_is_on = status
             self._attr_available = True
         else:

--- a/custom_components/idrac_power/button.py
+++ b/custom_components/idrac_power/button.py
@@ -35,7 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             if DATA_IDRAC_FIRMWARE in hass.data[DOMAIN][entry.entry_id]:
                 firmware_version = hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE]
         else:
-            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_INFO] = firmware_version
+            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE] = firmware_version
     except (CannotConnect, RedfishConfig) as e:
         raise PlatformNotReady(str(e)) from e
 

--- a/custom_components/idrac_power/manifest.json
+++ b/custom_components/idrac_power/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Breina/idrac_power_monitor/issues",
   "requirements": [],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/custom_components/idrac_power/sensor.py
+++ b/custom_components/idrac_power/sensor.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             if DATA_IDRAC_FIRMWARE in hass.data[DOMAIN][entry.entry_id]:
                 firmware_version = hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE]
         else:
-            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_INFO] = firmware_version
+            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE] = firmware_version
 
         thermal_info = await hass.async_add_executor_job(target=rest_client.update_thermals)
         if not thermal_info:
@@ -124,7 +124,7 @@ class IdracCurrentPowerSensor(SensorEntity):
         self.rest.register_callback_power_usage(self.update_value)
 
     def update_value(self, new_value: int | None):
-        if new_value:
+        if new_value is not None:
             self._attr_native_value = new_value
             self._attr_available = True
         else:

--- a/custom_components/idrac_power/switch.py
+++ b/custom_components/idrac_power/switch.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             if DATA_IDRAC_FIRMWARE in hass.data[DOMAIN][entry.entry_id]:
                 firmware_version = hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE]
         else:
-            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_INFO] = firmware_version
+            hass.data[DOMAIN][entry.entry_id][DATA_IDRAC_FIRMWARE] = firmware_version
     except (CannotConnect, RedfishConfig) as e:
         raise PlatformNotReady(str(e)) from e
 


### PR DESCRIPTION
## Summary

Fixes several bugs found during a code audit:

- **Firmware version overwrites device info**: `DATA_IDRAC_INFO` was used instead of `DATA_IDRAC_FIRMWARE` when caching the firmware version string, overwriting the device info dict. This could crash platform setup depending on async load order (`TypeError` on `info[JSON_MODEL]`). Affected all four platform files.
- **Power sensor: 0W = "unavailable"**: `if new_value:` treated `0` as falsy, marking the sensor unavailable instead of showing 0W. Fixed to `if new_value is not None:` (consistent with `IdracEnergyConsumptionSensor` which already used the correct check).
- **Status sensor: "off" = "unavailable"**: `if status:` treated `False` as falsy, making it impossible to see when a server was powered down. Fixed to `if status is not None:`.
- **Missing `async_unload_entry`**: The background polling task was never stopped on integration reload or removal, leading to zombie tasks and resource leaks. Added proper unload that cancels the task, unloads platforms, and cleans up `hass.data`.

## Test plan

- [ ] Verify integration loads without errors (check HA log for `TypeError` on setup)
- [ ] Power off the server via iDRAC and verify the status sensor shows "off" (not "unavailable")
- [ ] Reload the integration via HA UI and verify no duplicate polling tasks appear in logs
- [ ] Verify power and energy sensors still report correct values during normal operation